### PR TITLE
SYS-1684: Python package for the Alma API Client

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,0 +1,36 @@
+All software in this repository is Copyright © 2021+ The Regents of the University of
+California. All Rights Reserved.
+
+Permission to copy, modify, and distribute this software and its
+documentation for educational, research and non-profit purposes,
+without fee, and without a written agreement is hereby granted,
+provided that the above copyright notice, this paragraph and the
+following three paragraphs appear in all copies.
+
+Permission to make commercial use of this software may be obtained by
+contacting:
+
+Technology Transfer Office
+10889 Wilshire Blvd, Suite 920
+Los Angeles, CA 90095-7191
+(310) 794-0558
+info@tdg.ucla.edu
+
+This software program and documentation are copyrighted by The Regents
+of the University of California. The software program and
+documentation are supplied "as is", without any accompanying services
+from The Regents. The Regents does not warrant that the operation of
+the program will be uninterrupted or error-free. The end-user
+understands that the program was developed for research purposes and
+is advised not to rely exclusively on the program for any reason.
+
+IN NO EVENT SHALL THE UNIVERSITY OF CALIFORNIA BE LIABLE TO ANY PARTY
+FOR DIRECT, INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES,
+INCLUDING LOST PROFITS, ARISING OUT OF THE USE OF THIS SOFTWARE AND
+ITS DOCUMENTATION, EVEN IF THE UNIVERSITY OF CALIFORNIA HAS BEEN
+ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. THE UNIVERSITY OF
+CALIFORNIA SPECIFICALLY DISCLAIMS ANY WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE.  THE SOFTWARE PROVIDED HEREUNDER IS ON AN "AS
+IS" BASIS, AND THE UNIVERSITY OF CALIFORNIA HAS NO OBLIGATIONS TO
+PROVIDE MAINTENANCE, SUPPORT, UPDATES, ENHANCEMENTS, OR MODIFICATIONS.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,15 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "alma_api_client"
+version = "0.0.1"
+description = "Python client for the Alma API"
+readme = "README.md"
+requires-python = ">=3.9"
+classifiers = ["Programming Language :: Python :: 3"]
+dependencies = ["xmltodict", "requests", "pymarc"]
+
+[project.urls]
+Homepage = "https://github.com/UCLALibrary/alma-api-client"

--- a/src/alma_api_client/__init__.py
+++ b/src/alma_api_client/__init__.py
@@ -1,0 +1,3 @@
+from .alma_api_client import AlmaAPIClient
+from .alma_analytics_client import AlmaAnalyticsClient
+from .alma_marc import get_pymarc_record_from_bib, prepare_bib_for_update

--- a/src/alma_api_client/alma_analytics_client.py
+++ b/src/alma_api_client/alma_analytics_client.py
@@ -1,0 +1,186 @@
+import json
+import xmltodict
+from alma_api_client import AlmaAPIClient
+
+
+class AlmaAnalyticsClient:
+    def __init__(self, api_key: str) -> None:
+        self.API_KEY = api_key
+        self.FILTER_XML_NAMESPACES = """
+            xmlns:saw="com.siebel.analytics.web/report/v1.1"
+            xmlns:sawx="com.siebel.analytics.web/expression/v1.1"
+            xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+            xmlns:xsd="http://www.w3.org/2001/XMLSchema"
+        """
+
+        self.alma_client = AlmaAPIClient(self.API_KEY)
+        self.column_names: bool = True
+        self.filter: str = None
+        self.report_path: str = None
+        self.rows_per_fetch: int = 1000
+
+    def set_filter_xml(self, filter_xml: str) -> None:
+        """Set filter which will be applied to Analytics report.
+        Caller is responsible for building full XML required.
+        Analytics report must already have an "Is prompted" filter
+        on the given table and field.
+        """
+        self.filter = self._clean_filter_xml(filter_xml)
+
+    def set_filter_equal(self, table_name: str, field_name: str, value: str) -> None:
+        """Set filter for single-field 'EQUAL' comparison.
+
+        Analytics report must already have an "Is prompted" filter
+        on the given table and field.
+        """
+        filter_xml = f"""
+        <sawx:expr xsi:type="sawx:comparison" op="equal"
+            {self.FILTER_XML_NAMESPACES}
+        >
+            <sawx:expr xsi:type="sawx:sqlExpression">"{table_name}"."{field_name}"</sawx:expr>
+            <sawx:expr xsi:type="xsd:string">{value}</sawx:expr>
+        </sawx:expr>
+        """
+        self.filter = self._clean_filter_xml(filter_xml)
+
+    def set_filter_like(self, table_name: str, field_name: str, value: str) -> None:
+        """Set filter for single-field 'LIKE' comparison.
+
+        value parameter must have SQL wildcard(s).
+        Analytics report must already have an "Is prompted" filter
+        on the given table and field.
+        """
+        filter_xml = f"""
+        <sawx:expr xsi:type="sawx:list" op="like"
+            {self.FILTER_XML_NAMESPACES}
+        >
+            <sawx:expr xsi:type="sawx:sqlExpression">"{table_name}"."{field_name}"</sawx:expr>
+            <sawx:expr xsi:type="xsd:string">{value}</sawx:expr>
+        </sawx:expr>
+        """
+        self.filter = self._clean_filter_xml(filter_xml)
+
+    def set_report_path(self, report_path: str) -> None:
+        """Set full path to report in Analytics.
+        Path must not be URL-escaped.
+        """
+        self.report_path = report_path
+
+    def set_rows_per_fetch(self, rows_per_fetch: int) -> None:
+        """Set number of rows to fetch per API call.
+        Valid values: 25 to 1000, best as multiple of 25
+
+        The only real reason to call this: testing iteration code.
+        """
+        self.rows_per_fetch = rows_per_fetch
+
+    def get_report(self) -> dict:
+        """Run Analytics report and return data."""
+        if self.report_path is None:
+            raise ValueError("Path to report must be set")
+        # Used with every API call
+        constant_params = {
+            "col_names": self.column_names,
+            "limit": self.rows_per_fetch,
+        }
+        initial_params = {
+            "filter": self.filter,
+            "path": self.report_path,
+        }
+        # TODO: Use Python 3.9+ merge syntax, when server is upgraded...
+        # params = constant_params | initial_params
+        # First run: use constant + initial parameters merged
+        # Python < 3.9 merge
+        params = {**constant_params, **initial_params}
+        report = self.alma_client.get_analytics_report(params)
+        # Get data in usable format
+        report_data = self._get_report_data(report)
+        # Initial set of rows
+        all_rows = self._get_rows(report_data)
+
+        # Preserve column_names as they don't seem to be set on subsequent runs
+        column_names = report_data["column_names"]
+        # Use the token from first run in all subsequent ones
+        subsequent_params = {
+            "token": report_data["resumption_token"],
+        }
+
+        while report_data["is_finished"] == "false":
+            # After first run: use constant = subsequent parameters merged
+            # TODO: Use Python 3.9+ merge syntax, when server is upgraded...
+            # params = constant_params | subsequent_params
+            params = {**constant_params, **subsequent_params}
+            report = self.alma_client.get_analytics_report(params)
+            report_data = self._get_report_data(report)
+            all_rows.extend(self._get_rows(report_data))
+
+        # Replace generic column names with real ones
+        final_data = self._apply_column_names(column_names, all_rows)
+        return final_data
+
+    def _get_report_data(self, xml_report: dict) -> dict:
+        """Return usable data from XML the Analytics API uses."""
+        # Report available only in XML
+        # Entire XML report is a "list" with one value, in 'anies' element of json response
+        xml: str = xml_report["anies"][0]
+        # Convert xml to python dict intermediate format
+        xml_dict = xmltodict.parse(xml)
+        # Convert this to real dict
+        temp_dict: dict = json.loads(json.dumps(xml_dict))
+        # Everything is in QueryResult dict
+        report_dict = temp_dict["QueryResult"]
+        # Actual rows of data are a list of dictionaries, in this dictionary
+        rows: list = report_dict["ResultXml"]["rowset"]["Row"]
+
+        # Clean up
+        report_data: dict = {
+            "rows": rows,
+            "column_names": self._get_real_column_names(report_dict),
+            "is_finished": report_dict["IsFinished"],  # should always exist
+            "resumption_token": report_dict.get("ResumptionToken"),  # may not exist
+        }
+
+        return report_data
+
+    def _get_real_column_names(self, report_dict: dict) -> dict:
+        """Get real column names from report metadata."""
+        column_names = {}
+        try:
+            column_info = report_dict["ResultXml"]["rowset"]["xsd:schema"][
+                "xsd:complexType"
+            ]["xsd:sequence"]["xsd:element"]
+            # Create mapping of generic column names (Column0 etc.) to real column names
+            for row in column_info:
+                generic_name = row["@name"]
+                real_name = row["@saw-sql:columnHeading"]
+                column_names[generic_name] = real_name
+        except KeyError:
+            # OK to swallow this error
+            pass
+        return column_names
+
+    def _apply_column_names(self, column_names: dict, data_rows: list) -> list:
+        """Map real column names onto data rows, replacing generic ColumnN names.
+        Remove meaningless Column0.
+        """
+        data = []
+        for row in data_rows:
+            # Update keys to use real column names, removing meaningless Column0
+            new_row = dict(
+                [(column_names.get(k), v) for k, v in row.items() if k != "Column0"]
+            )
+            data.append(new_row)
+        return data
+
+    def _clean_filter_xml(self, filter_xml: str) -> str:
+        """Strip out formatting characters which make API unhappy."""
+        return filter_xml.replace("\n", "").replace("\t", "")
+
+    def _get_rows(self, report_data: dict) -> dict:
+        """Convert single-row bare dict to a list containing that dict, if needed."""
+        # This is a list of dictionaries if > 1 row...
+        # but just a dictionary if only 1 row.
+        rows = report_data.get("rows")
+        if isinstance(rows, dict):
+            rows = [rows]
+        return rows

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -1,0 +1,332 @@
+import requests
+from time import sleep
+
+
+class AlmaAPIClient:
+    def __init__(self, api_key: str) -> None:
+        self.API_KEY = api_key
+        self.BASE_URL = "https://api-na.hosted.exlibrisgroup.com"
+
+    def _get_headers(self, format: str = "json") -> dict:
+        return {
+            "Authorization": f"apikey {self.API_KEY}",
+            "Accept": f"application/{format}",
+            "Content-Type": f"application/{format}",
+        }
+
+    def _get_api_data(self, response: requests.Response, format: str = "json") -> dict:
+        """Return dictionary with response content and selected response headers.
+
+        If format is not json, the (presumably) XML content is in api_data["content"],
+        as a byte array.
+        """
+        try:
+            if format == "json":
+                api_data: dict = response.json()
+            else:
+                api_data = {"content": response.content}
+        except requests.exceptions.JSONDecodeError:
+            # Some responses return nothing, which can't be decoded...
+            api_data = {}
+        # Add a few response elements caller can use
+        api_data["api_response"] = {
+            "headers": response.headers,
+            "status_code": response.status_code,
+            "request_url": response.url,
+        }
+        return api_data
+
+    def _call_get_api(
+        self, api: str, parameters: dict = None, format: str = "json"
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        get_url = self.BASE_URL + api
+        headers = self._get_headers(format)
+        response = requests.get(get_url, headers=headers, params=parameters)
+        api_data: dict = self._get_api_data(response, format)
+        return api_data
+
+    def _call_post_api(
+        self, api: str, data: dict, parameters: dict = None, format: str = "json"
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        post_url = self.BASE_URL + api
+        headers = self._get_headers(format)
+        # TODO: Non-JSON POST?
+        response = requests.post(
+            post_url, headers=headers, json=data, params=parameters
+        )
+        api_data: dict = self._get_api_data(response, format)
+        return api_data
+
+    def _call_put_api(
+        self, api: str, data: str, parameters: dict = None, format: str = "json"
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        headers = self._get_headers(format)
+        put_url = self.BASE_URL + api
+        # Handle both XML (required by update_bib) and default JSON
+        if format == "xml":
+            response = requests.put(
+                put_url, headers=headers, data=data, params=parameters
+            )
+        else:
+            # json default
+            response = requests.put(
+                put_url, headers=headers, json=data, params=parameters
+            )
+        api_data: dict = self._get_api_data(response, format)
+        return api_data
+
+    def _call_delete_api(
+        self, api: str, parameters: dict = None, format: str = "json"
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        delete_url = self.BASE_URL + api
+        headers = self._get_headers(format)
+        response = requests.delete(delete_url, headers=headers, params=parameters)
+        # Success is HTTP 204, "No Content"
+        if response.status_code != 204:
+            # TODO: Real error handling
+            print(delete_url)
+            print(response.status_code)
+            print(response.headers)
+            print(response.text)
+            # exit(1)
+        api_data: dict = self._get_api_data(response, format)
+        return api_data
+
+    def create_item(
+        self, bib_id: str, holding_id: str, data: dict, parameters: dict = None
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{bib_id}/holdings/{holding_id}/items"
+        return self._call_post_api(api, data, parameters)
+
+    def get_items(self, bib_id: str, holding_id: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{bib_id}/holdings/{holding_id}/items"
+        return self._call_get_api(api, parameters)
+
+    def get_integration_profiles(self, parameters: dict = None) -> dict:
+        # Caller can pass search parameters, but must deal with possible
+        # multiple matches.
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/conf/integration-profiles"
+        return self._call_get_api(api, parameters)
+
+    def get_jobs(self, parameters: dict = None) -> dict:
+        # Caller normally will pass parameters, but they're not required.
+        # Caller must deal with possible multiple matches.
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/conf/jobs"
+        return self._call_get_api(api, parameters)
+
+    def run_job(self, job_id, data: dict = None, parameters: dict = None) -> dict:
+        # Tells Alma to queue / run a job; does *not* wait for completion.
+        # Caller must provide job_id outside of parameters.
+        # Running a scheduled job requires empty data {}; not sure about other jobs
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/conf/jobs/{job_id}"
+        return self._call_post_api(api, data, parameters)
+
+    def wait_for_completion(
+        self, job_id: str, instance_id: str, seconds_to_poll: int = 15
+    ) -> dict:
+        # Running a job just queues it to run; Alma assigns an instance id.
+        # This method allows the caller to wait until the given instance of
+        # the job has completed.
+        api = f"/almaws/v1/conf/jobs/{job_id}/instances/{instance_id}"
+        # progress value (0-100) can't be used as it remains 0 if FAILED.
+        # Use status instead; values from
+        # https://developers.exlibrisgroup.com/alma/apis/docs/xsd/rest_job_instance.xsd/
+        status = "NONE"  # Fake value until API is called.
+        while status in [
+            "NONE",
+            "QUEUED",
+            "PENDING",
+            "INITIALIZING",
+            "RUNNING",
+            "FINALIZING",
+        ]:
+            instance = self._call_get_api(api)
+            status = instance["status"]["value"]
+            print(status)
+            sleep(seconds_to_poll)
+        return instance
+
+    def get_fees(self, user_id: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/users/{user_id}/fees"
+        return self._call_get_api(api, parameters)
+
+    def get_analytics_report(self, parameters: dict = None) -> dict:
+        # Docs say to URL-encode report name (path);
+        # request lib is doing it automatically.
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/analytics/reports"
+        return self._call_get_api(api, parameters)
+
+    def get_analytics_path(self, path: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/analytics/paths/{path}"
+        return self._call_get_api(api, parameters)
+
+    def get_vendors(self, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/acq/vendors"
+        return self._call_get_api(api, parameters)
+
+    def get_vendor(self, vendor_code: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/acq/vendors/{vendor_code}"
+        return self._call_get_api(api, parameters)
+
+    def get_bib(self, mms_id: str, parameters: dict = None) -> dict:
+        """Return dictionary response, with Alma bib record (in Alma XML format),
+        in "content" element.
+        """
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}"
+        return self._call_get_api(api, parameters, format="xml")
+
+    def update_bib(self, mms_id: str, data: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}"
+        return self._call_put_api(api, data, parameters, format="xml")
+
+    def get_holding(
+        self, mms_id: str, holding_id: str, parameters: dict = None
+    ) -> dict:
+        """Return dictionary response, with Alma holding record (in Alma XML format),
+        in "content" element.
+        """
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}/holdings/{holding_id}"
+        return self._call_get_api(api, parameters, format="xml")
+
+    def update_holding(
+        self, mms_id: str, holding_id: str, data: str, parameters: dict = None
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{mms_id}/holdings/{holding_id}"
+        return self._call_put_api(api, data, format="xml")
+
+    def get_set_members(self, set_id: str, parameters: dict = None) -> None:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/conf/sets/{set_id}/members"
+        return self._call_get_api(api, parameters)
+
+    def create_user(self, user: dict, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/users"
+        return self._call_post_api(api, user, parameters)
+
+    def delete_user(self, user_id: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/users/{user_id}"
+        return self._call_delete_api(api, parameters)
+
+    def get_user(self, user_id: str, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/users/{user_id}"
+        return self._call_get_api(api, parameters)
+
+    def update_user(self, user_id: str, user: dict, parameters: dict = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/users/{user_id}"
+        return self._call_put_api(api, user, parameters)
+
+    def get_general_configuration(self) -> dict:
+        """Return general configuration info.
+        Useful for checking production / sandbox via environment_type.
+        """
+        api = "/almaws/v1/conf/general"
+        return self._call_get_api(api)
+
+    def get_code_tables(self) -> dict:
+        """Return list of code tables.  This specific API is undocumented."""
+        api = "/almaws/v1/conf/code-tables"
+        return self._call_get_api(api)
+
+    def get_code_table(self, code_table: str, parameters: dict = None) -> dict:
+        """Return specific code table, via name from get_code_tables()."""
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/conf/code-tables/{code_table}"
+        return self._call_get_api(api, parameters)
+
+    def get_mapping_tables(self) -> dict:
+        """Return list of mapping tables.  This specific API is undocumented."""
+        api = "/almaws/v1/conf/mapping-tables"
+        return self._call_get_api(api)
+
+    def get_mapping_table(self, mapping_table: str, parameters: dict = None) -> dict:
+        """Return specific mapping table, via name from get_mapping_tables()."""
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/conf/code-tables/{mapping_table}"
+        return self._call_get_api(api, parameters)
+
+    def get_libraries(self) -> dict:
+        """Return all libraries."""
+        api = "/almaws/v1/conf/libraries"
+        return self._call_get_api(api)
+
+    def get_library(self, library_code: str) -> dict:
+        """Return data for a single library, via code.
+        Doesn't provide more details than each entry in get_libaries().
+        """
+        api = f"/almaws/v1/conf/libraries/{library_code}"
+        return self._call_get_api(api)
+
+    def get_circulation_desks(self, library_code: str, parameters: dict = None) -> dict:
+        """Return data about circ desks in a single library, via code."""
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/conf/libraries/{library_code}/circ-desks/"
+        return self._call_get_api(api, parameters)
+
+    def get_funds(self, parameters: dict = None) -> dict:
+        """Return data about all funds matching search in parameters."""
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/acq/funds"
+        return self._call_get_api(api, parameters)
+
+    def get_fund(self, fund_id: str, parameters: dict = None) -> dict:
+        """Return data about a specific fund."""
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/acq/funds/{fund_id}"
+        return self._call_get_api(api, parameters)
+
+    def update_fund(self, fund_id: str, fund: dict, parameters: dict = None) -> dict:
+        """Update a specific fund."""
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/acq/funds/{fund_id}"
+        return self._call_put_api(api, fund, parameters)

--- a/src/alma_api_client/alma_marc.py
+++ b/src/alma_api_client/alma_marc.py
@@ -1,0 +1,36 @@
+import xml.etree.ElementTree as ET
+from pymarc import parse_xml_to_array, record_to_xml_node, Record
+from io import BytesIO
+
+
+def get_pymarc_record_from_bib(alma_bib: bytes) -> Record:
+    """Takes an Alma Bib and returns a pymarc Record containing <record> content."""
+    root = ET.fromstring(alma_bib)
+    record = root.find("record")
+
+    # xml_declaration=False since we want only the <record> element, not a full XML doc
+    marc_xml = ET.tostring(record, encoding="utf8", method="xml", xml_declaration=False)
+    # pymarc needs file-like object
+    with BytesIO(marc_xml) as fh:
+        pymarc_record = parse_xml_to_array(fh)[0]
+    return pymarc_record
+
+
+def prepare_bib_for_update(original_bib: bytes, new_record: Record) -> bytes:
+    """Takes an Alma Bib and a pymarc Record and returns an updated Bib bytestring
+    containing data from the new Record in the <record> element."""
+    # convert Bib and Record to ET Elements,
+    # using pymarc's record_to_xml_node for new_record
+    bib_element = ET.fromstring(original_bib)
+    new_record_element = record_to_xml_node(new_record)
+
+    old_record_element = bib_element.find("record")
+    bib_element.remove(old_record_element)
+    bib_element.append(new_record_element)
+
+    # xml_declaration=False because the Update Bib API doesn't require it, and the API
+    # call fails if xml_declaration=True due to escape characters in ET's declaration
+    bib_xml = ET.tostring(
+        bib_element, encoding="utf8", method="xml", xml_declaration=False
+    )
+    return bib_xml


### PR DESCRIPTION
Implements [SYS-1684](https://uclalibrary.atlassian.net/browse/SYS-1684)

A new Python package containing existing Alma API code. For testing, this can be installed directly from GitHub using `pip` and `git`:
`pip install git+https://github.com/UCLALibrary/alma-api-client@SYS-1684/alma-api-package`

The package can then be imported and used. For example:
```
>>> from alma_api_client import AlmaAPIClient, get_pymarc_record_from_bib
>>> client = AlmaAPIClient(API_KEYS["SANDBOX"]) # actual Sandbox API key goes here
>>> alma_bib = client.get_bib("9911656853606533").get("content")
>>> pymarc_record = get_pymarc_record_from_bib(alma_bib)
```

This PR currently includes these files:
* LICENSE.txt: copied from existing [alma-scripts LICENSE.txt](https://github.com/UCLALibrary/alma-scripts/blob/main/LICENSE.txt)
* pyproject.toml: metadata and information about the package build.
  * I chose [hatchling](https://hatch.pypa.io/latest/) as the build backend because it was simple to use and included as an example in the the [Python packaging tutorial](https://packaging.python.org/en/latest/tutorials/packaging-projects).
  * I tagged the package as version 0.0.1 for now.
  * I set `requires-python = ">=3.9"`.  I know that the package works on 3.9 and 3.12, but I'm not sure what we want to explicitly support.
* `src` files:
  * `__init__.py` is written such that `AlmaAPIClient`, `AlmaAnalyticsClient`, `get_pymarc_record_from_bib`, and `prepare_bib_for_update` can be directly imported from the `alma_analytics_client` package.
  * alma_analytics_client.py, alma_api_client.py, and alma_marc.py are identical to the versions in the [alma-scripts repo](https://github.com/UCLALibrary/alma-scripts).

This PR does not include:
* Tests. While there are a few [tests for the Analytics client](https://github.com/UCLALibrary/alma-scripts/blob/main/tests/test_analytics_class.py) in the alma-scripts repo, they're closely tied to UCLA's specific environment.
* Distribution files. I saw that `dist/` is included in the `.gitignore`, and I'm not sure what the best practice is for dealing with these files (make users build them themselves? use github releases?)
* Documentation. I assume that eventually the README should be more useful, but I wasn't sure what was needed at this point.

[SYS-1684]: https://uclalibrary.atlassian.net/browse/SYS-1684?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ