### PR TITLE
SYS-1730: Fix type hints and update merge syntax

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alma_api_client"
-version = "0.0.1"
+version = "0.0.2"
 description = "Python client for the Alma API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/src/alma_api_client/alma_analytics_client.py
+++ b/src/alma_api_client/alma_analytics_client.py
@@ -74,7 +74,7 @@ class AlmaAnalyticsClient:
         """
         self.rows_per_fetch = rows_per_fetch
 
-    def get_report(self) -> dict:
+    def get_report(self) -> list[dict]:
         """Run Analytics report and return data."""
         if self.report_path is None:
             raise ValueError("Path to report must be set")
@@ -87,11 +87,8 @@ class AlmaAnalyticsClient:
             "filter": self.filter,
             "path": self.report_path,
         }
-        # TODO: Use Python 3.9+ merge syntax, when server is upgraded...
-        # params = constant_params | initial_params
         # First run: use constant + initial parameters merged
-        # Python < 3.9 merge
-        params = {**constant_params, **initial_params}
+        params = constant_params | initial_params
         report = self.alma_client.get_analytics_report(params)
         # Get data in usable format
         report_data = self._get_report_data(report)
@@ -107,9 +104,7 @@ class AlmaAnalyticsClient:
 
         while report_data["is_finished"] == "false":
             # After first run: use constant = subsequent parameters merged
-            # TODO: Use Python 3.9+ merge syntax, when server is upgraded...
-            # params = constant_params | subsequent_params
-            params = {**constant_params, **subsequent_params}
+            params = constant_params | subsequent_params
             report = self.alma_client.get_analytics_report(params)
             report_data = self._get_report_data(report)
             all_rows.extend(self._get_rows(report_data))
@@ -176,7 +171,7 @@ class AlmaAnalyticsClient:
         """Strip out formatting characters which make API unhappy."""
         return filter_xml.replace("\n", "").replace("\t", "")
 
-    def _get_rows(self, report_data: dict) -> dict:
+    def _get_rows(self, report_data: dict) -> list:
         """Convert single-row bare dict to a list containing that dict, if needed."""
         # This is a list of dictionaries if > 1 row...
         # but just a dictionary if only 1 row.


### PR DESCRIPTION
Fixes [SYS-1730](https://uclalibrary.atlassian.net/browse/SYS-1730).

This fixes minor bugs with the return type hints of a few methods in `AlmaAnalyticsClient`, which I noticed when using it in our FTVA project.  These were carried over from the [original version](https://github.com/UCLALibrary/alma-scripts/blob/main/alma_analytics_client.py), which I'll fix separately.

It also updates the dictionary merge syntax from the old pre-3.9 Python, via a couple of TODOs which called that out.  Our package requires Python 3.9+ and our server has been updated since the original, so time to fix these.

I ran a report with the old and new versions of code, got the same results, so seems fine to me :)

Bumped package version to `0.0.2`.  No tests.


[SYS-1730]: https://uclalibrary.atlassian.net/browse/SYS-1730?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ