### PR TITLE
SYS-1954: Add support for Alma Sets

### DIFF
--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -58,21 +58,33 @@ class AlmaAPIClient:
         }
         return api_data
 
+    def _get_api_url(self, api: str) -> str:
+        """Get the full URL needed to call the API.  The base URL is aadded,
+        if the provided `api` does not already start with it.
+
+        :param api: The API, either as a full URL or the `/almaws/...` path.
+        :return url: The full URL for the API.
+        """
+        if api.startswith(self.BASE_URL):
+            return api
+        else:
+            return self.BASE_URL + api
+
     def _call_get_api(
         self, api: str, parameters: dict | None = None, format: str = "json"
     ) -> dict:
         """Send a GET request to the API.
 
-        :param api: The API to call, without the base URL.
+        :param api: The API to call, with or without the base URL.
         :param parameters: The optional request parameters.
         :param format: The desired format, expected to be json or xml.
         :return api_data: Response content and selected headers.
         """
         if parameters is None:
             parameters = {}
-        get_url = self.BASE_URL + api
+        api_url = self._get_api_url(api)
         headers = self._get_headers(format)
-        response = requests.get(get_url, headers=headers, params=parameters)
+        response = requests.get(api_url, headers=headers, params=parameters)
         api_data: dict = self._get_api_data(response, format)
         return api_data
 
@@ -81,7 +93,7 @@ class AlmaAPIClient:
     ) -> dict:
         """Send a POST request to the API.
 
-        :param api: The API to call, without the base URL.
+        :param api: The API to call, with or without the base URL.
         :param data: The data to send in the body of the request.
         :param parameters: The optional request parameters.
         :param format: The desired format, expected to be json or xml.
@@ -89,13 +101,11 @@ class AlmaAPIClient:
         """
         if parameters is None:
             parameters = {}
-        post_url = self.BASE_URL + api
+        api_url = self._get_api_url(api)
         headers = self._get_headers(format)
         # TODO: Non-JSON POST?
         # TODO: Enforce valid formats.
-        response = requests.post(
-            post_url, headers=headers, json=data, params=parameters
-        )
+        response = requests.post(api_url, headers=headers, json=data, params=parameters)
         api_data: dict = self._get_api_data(response, format)
         return api_data
 
@@ -104,7 +114,7 @@ class AlmaAPIClient:
     ) -> dict:
         """Send a PUT request to the API.
 
-        :param api: The API to call, without the base URL.
+        :param api: The API to call, with or without the base URL.
         :param data: The data to send in the body of the request.
         :param parameters: The optional request parameters.
         :param format: The desired format, expected to be json or xml.
@@ -113,17 +123,17 @@ class AlmaAPIClient:
         if parameters is None:
             parameters = {}
         headers = self._get_headers(format)
-        put_url = self.BASE_URL + api
+        api_url = self._get_api_url(api)
         # Handle both XML (required by update_bib) and default JSON
         # TODO: Enforce valid formats.
         if format == "xml":
             response = requests.put(
-                put_url, headers=headers, data=data, params=parameters
+                api_url, headers=headers, data=data, params=parameters
             )
         else:
             # json default
             response = requests.put(
-                put_url, headers=headers, json=data, params=parameters
+                api_url, headers=headers, json=data, params=parameters
             )
         api_data: dict = self._get_api_data(response, format)
         return api_data
@@ -133,20 +143,20 @@ class AlmaAPIClient:
     ) -> dict:
         """Send a DELETE request to the API.
 
-        :param api: The API to call, without the base URL.
+        :param api: The API to call, with or without the base URL.
         :param parameters: The optional request parameters.
         :param format: The desired format, expected to be json or xml.
         :return api_data: Response content and selected headers.
         """
         if parameters is None:
             parameters = {}
-        delete_url = self.BASE_URL + api
+        api_url = self._get_api_url(api)
         headers = self._get_headers(format)
-        response = requests.delete(delete_url, headers=headers, params=parameters)
+        response = requests.delete(api_url, headers=headers, params=parameters)
         # Success is HTTP 204, "No Content"
         if response.status_code != 204:
             # TODO: Real error handling
-            print(delete_url)
+            print(api_url)
             print(response.status_code)
             print(response.headers)
             print(response.text)

--- a/src/alma_api_client/models/sets.py
+++ b/src/alma_api_client/models/sets.py
@@ -37,6 +37,11 @@ class SetMember:
         return f"{self.description} : {self.link}"
 
     def _create_from_api_response(self, api_response: dict):
+        """Add attributes to this `SetMember` object based on data from the API response.
+
+        :param api_response: A dict of data provided by the Alma API.
+        :return: None
+        """
         self.id = api_response.get("id", "")
         self.description = api_response.get("description", "")
         self.link = api_response.get("link", "")
@@ -50,16 +55,32 @@ class Set:
         if api_response:
             self._create_from_api_response(api_response)
 
-    def _create_from_api_response(self, api_response: dict):
-        self.content_type = self._get_content_type_from_api_response(api_response)
+    def _create_from_api_response(self, api_response: dict) -> None:
+        """Add attributes to this `Set` object based on data from the API response.
+
+        :param api_response: A dict of data provided by the Alma API.
+        :return: None
+        """
         self.name = api_response.get("name", "")
+        self.content_type = self._get_content_type_from_api_response(api_response)
+
         member_info = api_response.get("number_of_members", {})
         self.number_of_members = member_info.get("value", 0)
         self.members_api = member_info.get("link", "")
 
     def _get_content_type_from_api_response(self, api_response: dict) -> SetContentType:
+        """Convert the set content type to an enum.
+
+        :param api_response: A dict of data provided by the Alma API.
+        :return: A `SetContentType` enum.
+        """
         content = api_response.get("content", {})
         return SetContentType(content.get("desc"))
 
     def add_members(self, members: list[SetMember]) -> None:
+        """Add a reference to the members of this Set.
+
+        :param members: A list of `SetMember` objects.
+        :return: None
+        """
         self.members = members

--- a/src/alma_api_client/models/sets.py
+++ b/src/alma_api_client/models/sets.py
@@ -28,6 +28,20 @@ class SetContentType(Enum):
     VENDOR = "Vendor"
 
 
+class SetMember:
+    def __init__(self, api_response: dict) -> None:
+        if api_response:
+            self._create_from_api_response(api_response)
+
+    def __str__(self) -> str:
+        return f"{self.description} : {self.link}"
+
+    def _create_from_api_response(self, api_response: dict):
+        self.id = api_response.get("id", "")
+        self.description = api_response.get("description", "")
+        self.link = api_response.get("link", "")
+
+
 class Set:
     def __init__(self, name: str = "", api_response: dict | None = None) -> None:
         # Other fields could be added here, but unless we're creating sets from
@@ -47,19 +61,5 @@ class Set:
         content = api_response.get("content", {})
         return SetContentType(content.get("desc"))
 
-    def add_members(self, members: list) -> None:
+    def add_members(self, members: list[SetMember]) -> None:
         self.members = members
-
-
-class SetMember:
-    def __init__(self, api_response: dict) -> None:
-        if api_response:
-            self._create_from_api_response(api_response)
-
-    def __str__(self) -> str:
-        return f"{self.description} : {self.link}"
-
-    def _create_from_api_response(self, api_response: dict):
-        self.id = api_response.get("id", "")
-        self.description = api_response.get("description", "")
-        self.link = api_response.get("link", "")

--- a/src/alma_api_client/models/sets.py
+++ b/src/alma_api_client/models/sets.py
@@ -1,0 +1,65 @@
+from enum import Enum
+
+
+# Derived from /almaws/v1/conf/code-tables/SetContentType
+class SetContentType(Enum):
+    AUTHORITY_MMS = "Authorities"
+    BIB_MMS = "All Titles"
+    BIB_MMS_DISCOVERY = "All Discovery Titles"
+    COURSE = "Courses"
+    FILE = "Digital files"
+    HOLDING = "Physical holdings"
+    IEC = "Collections"
+    IED = "Digital titles"
+    IEE = "Electronic titles"
+    IE = "Inventory titles"
+    IEPA = "Electronic collections"
+    IEP = "Physical titles"
+    IER = "Research assets"
+    ITEM = "Physical items"
+    PO_LINE = "Order lines"
+    PORTFOLIO = "Electronic portfolios"
+    READING_LIST_CITATION = "Citations"
+    READING_LIST = "Reading lists"
+    REMOTE_REPRESENTATION = "Digital remote representations"
+    REPRESENTATION = "Digital representations"
+    RESEARCHERS = "Researchers"
+    USER = "User"
+    VENDOR = "Vendor"
+
+
+class Set:
+    def __init__(self, name: str = "", api_response: dict | None = None) -> None:
+        # Other fields could be added here, but unless we're creating sets from
+        # scratch via API, I don't see a need.
+        self.name = name
+        if api_response:
+            self._create_from_api_response(api_response)
+
+    def _create_from_api_response(self, api_response: dict):
+        self.content_type = self._get_content_type_from_api_response(api_response)
+        self.name = api_response.get("name", "")
+        member_info = api_response.get("number_of_members", {})
+        self.number_of_members = member_info.get("value", 0)
+        self.members_api = member_info.get("link", "")
+
+    def _get_content_type_from_api_response(self, api_response: dict) -> SetContentType:
+        content = api_response.get("content", {})
+        return SetContentType(content.get("desc"))
+
+    def add_members(self, members: list) -> None:
+        self.members = members
+
+
+class SetMember:
+    def __init__(self, api_response: dict) -> None:
+        if api_response:
+            self._create_from_api_response(api_response)
+
+    def __str__(self) -> str:
+        return f"{self.description} : {self.link}"
+
+    def _create_from_api_response(self, api_response: dict):
+        self.id = api_response.get("id", "")
+        self.description = api_response.get("description", "")
+        self.link = api_response.get("link", "")


### PR DESCRIPTION
Implements [SYS-1954](https://uclalibrary.atlassian.net/browse/SYS-1954).

This PR adds support for Alma Sets, which are collections of things within Alma (e.g., items, bibs, users, and more).  These things are modeled generically as `SetMember`s, with a `SetContentType` enum to provide more information.  Set members are generic references to real things in Alma.

There is one new method in `alma_api_client`: `get_set(set_id, get_all_members`).  This returns a `Set` with some basic high-level info (name, number of members, content type).  By default, all set members are retrieved, stored as a list of `SetMember`s.

This is noted as "Experimental" in the API client for now, as we're still deciding how (or if) we'll proceed with this approach.  There are no breaking changes; the existing `get_set_members(set_id)` method is unchanged, though it's only used by an earlier script in `alma-scripts` I was experimenting with earlier.

The only other changes in `alma_api_client.py` are improved type hints, and an internal `_get_api_url()` method I wrote to handle both our default `/path/to/api` and full `https://base_url/path_to_api` URLs.


[SYS-1954]: https://uclalibrary.atlassian.net/browse/SYS-1954?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ