### PR TITLE
SYS-1971: Improve MARC support with Alma API client

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.13-slim-bookworm
+FROM python:3.11-slim-bookworm
 
 # Update base image
 RUN apt-get update

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,13 @@ name = "alma_api_client"
 version = "0.1.0"
 description = "Python client for the Alma API"
 readme = "README.md"
-requires-python = ">=3.9"
+requires-python = ">=3.11"
 classifiers = ["Programming Language :: Python :: 3"]
 dependencies = [
     "pymarc==5.3.1",
     "requests==2.32.4",
     "xmltodict==0.14.2",
+    "typing_extensions==4.15.0",
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "alma_api_client"
-version = "0.0.2"
+version = "0.1.0"
 description = "Python client for the Alma API"
 readme = "README.md"
 requires-python = ">=3.9"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 pymarc==5.3.1
 requests==2.32.4
 xmltodict==0.14.2
+
+# For possible later use
+# retry==0.9.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,8 @@ pymarc==5.3.1
 requests==2.32.4
 xmltodict==0.14.2
 
+# For Python 3.11 compatibility
+typing_extensions==4.15.0
+
 # For possible later use
 # retry==0.9.2

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -491,11 +491,28 @@ class AlmaAPIClient:
         api_response = self._get_marc_record(api, parameters)
         return HoldingsRecord(api_response)
 
+    def create_bib_record(
+        self, bib_record: BibRecord, parameters: dict | None = None
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = "/almaws/v1/bibs"
+        data = bib_record.alma_xml
+        # TODO: Return the actual record created.
+        return self._call_post_api(api, data, parameters, format="xml")
+
     def update_bib_record(
         self, bib_id: str, bib_record: BibRecord, parameters: dict | None = None
     ) -> dict:
         if parameters is None:
             parameters = {}
         api = f"/almaws/v1/bibs/{bib_id}"
-        data = bib_record.prepare_xml_for_update()
+        data = bib_record.alma_xml
+        # TODO: Return the actual record updated.
         return self._call_put_api(api, data, parameters, format="xml")
+
+    def delete_bib_record(self, bib_id: str, parameters: dict | None = None) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{bib_id}"
+        return self._call_delete_api(api, parameters)

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -8,7 +8,7 @@ from .models.sets import Set, SetMember
 from .models.marc_records import (
     AuthorityRecord,
     BibRecord,
-    HoldingsRecord,
+    HoldingRecord,
 )
 
 
@@ -300,7 +300,7 @@ class AlmaAPIClient:
         api = f"/almaws/v1/bibs/{mms_id}"
         return self._call_put_api(api, data, parameters, format="xml")
 
-    @deprecated("Use get_holdings_record() instead")
+    @deprecated("Use get_holding_record() instead")
     def get_holding(
         self, mms_id: str, holding_id: str, parameters: dict | None = None
     ) -> dict:
@@ -484,12 +484,14 @@ class AlmaAPIClient:
         api_response = self._get_marc_record(api, parameters)
         return BibRecord(api_response)
 
-    def get_holdings_record(
-        self, bib_id: str, holdings_id: str, parameters: dict | None = None
-    ) -> HoldingsRecord:
-        api = f"/almaws/v1/bibs/{bib_id}/holdings/{holdings_id}"
+    def get_holding_record(
+        self, bib_id: str, holding_id: str, parameters: dict | None = None
+    ) -> HoldingRecord:
+        api = f"/almaws/v1/bibs/{bib_id}/holdings/{holding_id}"
         api_response = self._get_marc_record(api, parameters)
-        return HoldingsRecord(api_response)
+        # TODO: Consider adding bib_id to holding record, which does not get it
+        # from API response.
+        return HoldingRecord(api_response)
 
     def create_bib_record(
         self, bib_record: BibRecord, parameters: dict | None = None
@@ -515,4 +517,36 @@ class AlmaAPIClient:
         if parameters is None:
             parameters = {}
         api = f"/almaws/v1/bibs/{bib_id}"
+        return self._call_delete_api(api, parameters)
+
+    def create_holding_record(
+        self, bib_id: str, holding_record: HoldingRecord, parameters: dict | None = None
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{bib_id}/holdings"
+        data = holding_record.alma_xml
+        # TODO: Return the actual record created.
+        return self._call_post_api(api, data, parameters, format="xml")
+
+    def update_holding_record(
+        self,
+        bib_id: str,
+        holding_record: HoldingRecord,
+        parameters: dict | None = None,
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        holding_id = holding_record.holding_id
+        api = f"/almaws/v1/bibs/{bib_id}/holdings/{holding_id}"
+        data = holding_record.alma_xml
+        # TODO: Return the actual record updated.
+        return self._call_put_api(api, data, format="xml")
+
+    def delete_holding_record(
+        self, bib_id: str, holding_id: str, parameters: dict | None = None
+    ) -> dict:
+        if parameters is None:
+            parameters = {}
+        api = f"/almaws/v1/bibs/{bib_id}/holdings/{holding_id}"
         return self._call_delete_api(api, parameters)

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -1,9 +1,11 @@
 import requests
 from time import sleep
-from typing import Union
-from warnings import deprecated
+from typing import Union, TypeAlias
 
-# TODO: Experimental
+# TODO: Once 3.13 is supported, update this.
+# from warnings import deprecated # Python 3.13+
+from typing_extensions import deprecated  # Python 3.11
+
 from .models.sets import Set, SetMember
 from .models.marc_records import (
     AuthorityRecord,
@@ -15,7 +17,9 @@ from .models.marc_records import (
 # For requests data parameter, which is very flexible;
 # (optional) Dictionary, list of tuples, bytes, or file-like object to send...
 # this is better than Any.
-type Data = Union[bytes, dict, list[tuple]]
+# TODO: Once 3.13 is supported, update this:
+# type Data = Union[bytes, dict, list[tuple]] # Python 3.12+
+Data: TypeAlias = Union[bytes, dict, list[tuple]]  # Python 3.11
 
 
 class AlmaAPIClient:

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -482,7 +482,7 @@ class AlmaAPIClient:
         # as well as response status.
         # Will require updating all client methods.
         # For now, this is isolated to the new record retrieval methods.
-        if api_data.get("api_response", {}).get("status_code", "") != "200":
+        if api_data.get("api_response", {}).get("status_code", "") != 200:
             raise ValueError(f"Unable to get MARC record for {api}")
         else:
             return api_data

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -476,16 +476,39 @@ class AlmaAPIClient:
     ) -> dict:
         if parameters is None:
             parameters = {}
-        return self._call_get_api(api, parameters, format="xml")
+        api_data = self._call_get_api(api, parameters, format="xml")
+        # TODO: Change _get_api_data() to return an object which exposes attributes
+        # in a more friendly way. This could involve parsing XML for error messages & codes,
+        # as well as response status.
+        # Will require updating all client methods.
+        # For now, this is isolated to the new record retrieval methods.
+        if api_data.get("api_response", {}).get("status_code", "") != "200":
+            raise ValueError(f"Unable to get MARC record for {api}")
+        else:
+            return api_data
 
     def get_authority_record(
         self, authority_id: str, parameters: dict | None = None
     ) -> AuthorityRecord:
+        """Retrieve authority record from Alma, as an `AuthorityRecord`.
+
+        :param authority_id: The Alma authority record id.
+        :param parameters: Other parameters, see Alma documentation for details.
+        :raises: `ValueError`, if Alma cannot find a record matching the id.
+        :return: The record.
+        """
         api = f"/almaws/v1/bibs/authorities/{authority_id}"
         api_response = self._get_marc_record(api, parameters)
         return AuthorityRecord(api_response)
 
     def get_bib_record(self, bib_id: str, parameters: dict | None = None) -> BibRecord:
+        """Retrieve bibliographic record from Alma, as a `BibRecord`.
+
+        :param bib_id: The Alma bib record id.
+        :param parameters: Other parameters, see Alma documentation for details.
+        :raises: `ValueError`, if Alma cannot find a record matching the id.
+        :return: The record.
+        """
         api = f"/almaws/v1/bibs/{bib_id}"
         api_response = self._get_marc_record(api, parameters)
         return BibRecord(api_response)
@@ -493,6 +516,14 @@ class AlmaAPIClient:
     def get_holding_record(
         self, bib_id: str, holding_id: str, parameters: dict | None = None
     ) -> HoldingRecord:
+        """Retrieve holding record from Alma, as an `HoldingRecord`.
+
+        :param bib_id: The Alma bib record id.
+        :param holding_id: The Alma holding record id.
+        :param parameters: Other parameters, see Alma documentation for details.
+        :raises: `ValueError`, if Alma cannot find a record matching the id.
+        :return: The record.
+        """
         api = f"/almaws/v1/bibs/{bib_id}/holdings/{holding_id}"
         api_response = self._get_marc_record(api, parameters)
         # TODO: Consider adding bib_id to holding record, which does not get it

--- a/src/alma_api_client/alma_api_client.py
+++ b/src/alma_api_client/alma_api_client.py
@@ -292,6 +292,7 @@ class AlmaAPIClient:
         api = f"/almaws/v1/bibs/{mms_id}"
         return self._call_get_api(api, parameters, format="xml")
 
+    @deprecated("Use update_bib_record() instead.")
     def update_bib(
         self, mms_id: str, data: bytes, parameters: dict | None = None
     ) -> dict:
@@ -312,6 +313,7 @@ class AlmaAPIClient:
         api = f"/almaws/v1/bibs/{mms_id}/holdings/{holding_id}"
         return self._call_get_api(api, parameters, format="xml")
 
+    @deprecated("Use get_holding_record() instead.")
     def update_holding(
         self, mms_id: str, holding_id: str, data: bytes, parameters: dict | None = None
     ) -> dict:

--- a/src/alma_api_client/alma_marc.py
+++ b/src/alma_api_client/alma_marc.py
@@ -1,21 +1,38 @@
 import xml.etree.ElementTree as ET
-from pymarc import parse_xml_to_array, record_to_xml_node, Record
 from io import BytesIO
+from pymarc import parse_xml_to_array, record_to_xml_node, Record
+from warnings import deprecated
 
 
+# TODO: Add / update deprecations
+@deprecated("Use get_pymarc_record_from_xml() instead.")
 def get_pymarc_record_from_bib(alma_bib: bytes) -> Record | None:
     """Convert an Alma bibliographic record, as returned by the API, to a
     pymarc Record containing <record> content.
 
+    This is now just a wrapper around `get_pymarc_record_from_xml`, and will
+    be removed in a future version.
+
     :param alma_bib: Data from the Alma API representing a bib record.
     :return pymarc_record: Pymarc record
     """
-    # TODO: Is this really just for bib records, or holdings / any MARC?
-    root = ET.fromstring(alma_bib)
+    return get_pymarc_record_from_xml(marc_xml=alma_bib)
+
+
+def get_pymarc_record_from_xml(marc_xml: bytes) -> Record | None:
+    """Convert a MARCXML record, as returned by the API, to a
+    pymarc Record.
+
+    :param marc_xml: Data from the Alma API representing a MARC record (biliographic or holdings).
+    :return pymarc_record: Pymarc record
+    """
+    root = ET.fromstring(marc_xml)
     record = root.find("record")
     if record:
         # xml_declaration=False since we want only the <record> element, not a full XML doc
-        marc_xml = ET.tostring(record, encoding="utf8", method="xml", xml_declaration=False)
+        marc_xml = ET.tostring(
+            record, encoding="utf8", method="xml", xml_declaration=False
+        )
         # pymarc needs file-like object
         with BytesIO(marc_xml) as fh:
             pymarc_record = parse_xml_to_array(fh)[0]

--- a/src/alma_api_client/alma_marc.py
+++ b/src/alma_api_client/alma_marc.py
@@ -1,7 +1,10 @@
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from pymarc import parse_xml_to_array, record_to_xml_node, Record
-from warnings import deprecated
+
+# TODO: Once 3.13 is supported, update this.
+# from warnings import deprecated # Python 3.13+
+from typing_extensions import deprecated  # Python 3.11
 
 
 # TODO: Add / update deprecations

--- a/src/alma_api_client/alma_marc.py
+++ b/src/alma_api_client/alma_marc.py
@@ -19,6 +19,7 @@ def get_pymarc_record_from_bib(alma_bib: bytes) -> Record | None:
     return get_pymarc_record_from_xml(marc_xml=alma_bib)
 
 
+@deprecated("Use classes from marc_records instead.")
 def get_pymarc_record_from_xml(marc_xml: bytes) -> Record | None:
     """Convert a MARCXML record, as returned by the API, to a
     pymarc Record.
@@ -41,6 +42,7 @@ def get_pymarc_record_from_xml(marc_xml: bytes) -> Record | None:
         return None
 
 
+@deprecated("Use classes from marc_records instead.")
 def prepare_bib_for_update(original_bib: bytes, new_record: Record) -> bytes | None:
     """Takes an Alma Bib and a pymarc Record and returns an updated Bib bytestring
     containing data from the new Record in the <record> element."""

--- a/src/alma_api_client/models/marc_records.py
+++ b/src/alma_api_client/models/marc_records.py
@@ -1,0 +1,68 @@
+import xml.etree.ElementTree as ET
+from io import BytesIO
+from pymarc import parse_xml_to_array, record_to_xml_node, Record
+
+
+class AlmaMARCRecord:
+    def __init__(self, api_response: dict) -> None:
+        if api_response:
+            self._create_from_api_response(api_response)
+
+    def _create_from_api_response(self, api_response: dict):
+        """Add attributes to this `AlmaMARCRecord` object based on data from the API response.
+
+        :param api_response: A dict of data provided by the Alma API.
+        :return: None
+        """
+        # The only relevant element in the API response is "content", which contains
+        # XML as bytes with UTF-8 encoding.
+        self.alma_xml: bytes = api_response.get("content", b"")
+        self.marc_record = self.get_pymarc_record_from_xml(self.alma_xml)
+
+    def get_pymarc_record_from_xml(self, alma_xml: bytes) -> Record | None:
+        """Convert a MARCXML record, as returned by the API, to a
+        pymarc Record.
+
+        :param alma_xml: Data from the Alma API representing a MARC record
+        (biliographic or holdings).
+        :return pymarc_record: Pymarc record
+        """
+        root = ET.fromstring(alma_xml)
+        record = root.find("record")
+        if record:
+            # xml_declaration=False since we want only the <record> element, not a full XML doc
+            alma_xml = ET.tostring(
+                record, encoding="utf8", method="xml", xml_declaration=False
+            )
+            # pymarc needs file-like object
+            with BytesIO(alma_xml) as fh:
+                pymarc_record = parse_xml_to_array(fh)[0]
+            return pymarc_record
+        else:
+            return None
+
+    def prepare_xml_for_update(self) -> bytes:
+        """Combines this object's pymarc record with the required Alma XML and returns
+        an updated bytes with MARCXML in the <record> element."""
+        # Convert data to ElementTree elements,
+        # using pymarc's record_to_xml_node to convert to MARCXML.
+        original_element = ET.fromstring(self.alma_xml)
+        new_record_element = record_to_xml_node(self.marc_record)
+
+        old_record_element = original_element.find("record")
+        # Replace the old <record> element with the current MARCXML.
+        if old_record_element:
+            original_element.remove(old_record_element)
+            original_element.append(new_record_element)
+
+            # xml_declaration=False because the Alma API doesn't require it, and the API
+            # call fails if xml_declaration=True due to escape characters in ET's declaration
+            final_alma_xml = ET.tostring(
+                original_element, encoding="utf8", method="xml", xml_declaration=False
+            )
+            self.alma_xml = final_alma_xml
+            return final_alma_xml
+        else:
+            # TODO: Understand what errors can happen and handle them correctly
+            # For now, if XML not updated, return original XML?
+            return self.alma_xml

--- a/src/alma_api_client/models/marc_records.py
+++ b/src/alma_api_client/models/marc_records.py
@@ -145,11 +145,11 @@ class BibRecord(AlmaMARCRecord):
         self._record_type = "bib"
 
     @property
-    def mms_id(self) -> str:
+    def bib_id(self) -> str:
         return self._all_attributes.get("mms_id", "")
 
 
-class HoldingsRecord(AlmaMARCRecord):
+class HoldingRecord(AlmaMARCRecord):
     # These attributes are in addition to those defined in the base class.
     __slots__ = [
         "suppress_from_publishing",
@@ -162,3 +162,7 @@ class HoldingsRecord(AlmaMARCRecord):
     @property
     def created_by(self) -> str:
         return self._all_attributes.get("created_by", "")
+
+    @property
+    def holding_id(self) -> str:
+        return self._all_attributes.get("holding_id", "")

--- a/src/alma_api_client/models/marc_records.py
+++ b/src/alma_api_client/models/marc_records.py
@@ -60,6 +60,8 @@ class AlmaMARCRecord:
         :return: None
         """
         # Convert XML to dictionary, since we hate XML.
+        # This gives something like:
+        # {'record_type': {'attribute_1': 'value_1', 'attribute_2': 'value_2'}}
         # TODO: Consider changing attr_prefix and cdata_key from xmltodict defaults.
         alma_data = xmltodict.parse(alma_xml)
 

--- a/src/alma_api_client/models/marc_records.py
+++ b/src/alma_api_client/models/marc_records.py
@@ -2,24 +2,35 @@ import xml.etree.ElementTree as ET
 from io import BytesIO
 from pymarc import parse_xml_to_array, record_to_xml_node, Record
 
+import xmltodict
+from pprint import pprint
+
 
 class AlmaMARCRecord:
-    def __init__(self, api_response: dict) -> None:
+    # In this base class, only the MARC record and the XML are available.
+    # Subclasses will add subclass-specific attributes.
+    __slots__ = ["marc_record", "_all_attributes", "_record_type"]
+
+    def __init__(self, api_response: dict | None = None) -> None:
         if api_response:
             self._create_from_api_response(api_response)
 
-    def _create_from_api_response(self, api_response: dict):
+    def _create_from_api_response(self, api_response: dict) -> None:
         """Add attributes to this `AlmaMARCRecord` object based on data from the API response.
 
         :param api_response: A dict of data provided by the Alma API.
         :return: None
         """
-        # The only relevant element in the API response is "content", which contains
+        # The most important element in the API response is "content", which contains
         # XML as bytes with UTF-8 encoding.
-        self.alma_xml: bytes = api_response.get("content", b"")
-        self.marc_record = self.get_pymarc_record_from_xml(self.alma_xml)
+        alma_xml: bytes = api_response.get("content", b"")
+        self.marc_record = self._get_pymarc_record_from_xml(alma_xml)
 
-    def get_pymarc_record_from_xml(self, alma_xml: bytes) -> Record | None:
+        # Some other XML elements may be relevant, especially for creating records.
+        # Those are defined in the class's __slots__, for exposure to class users.
+        self._set_attributes(alma_xml)
+
+    def _get_pymarc_record_from_xml(self, alma_xml: bytes) -> Record | None:
         """Convert a MARCXML record, as returned by the API, to a
         pymarc Record.
 
@@ -50,8 +61,8 @@ class AlmaMARCRecord:
         new_record_element = record_to_xml_node(self.marc_record)
 
         old_record_element = original_element.find("record")
-        # Replace the old <record> element with the current MARCXML.
-        if old_record_element:
+        if old_record_element is not None:
+            # Replace the old <record> element with the current MARCXML.
             original_element.remove(old_record_element)
             original_element.append(new_record_element)
 
@@ -66,3 +77,56 @@ class AlmaMARCRecord:
             # TODO: Understand what errors can happen and handle them correctly
             # For now, if XML not updated, return original XML?
             return self.alma_xml
+
+    def _set_attributes(self, alma_xml: bytes) -> None:
+        alma_data = xmltodict.parse(alma_xml)
+        pprint(alma_data, width=132)
+        # Set specific attributes defined in __slots__ for read/write access.
+        # There should be only one key in alma_data, indicating what type of record it is.
+        self._record_type = next(iter(alma_data))
+        attributes: dict = alma_data.get(self._record_type, {})
+        for key, value in attributes.items():
+            if key in self.__slots__:
+                setattr(self, key, value)
+
+        # Store as-is for read-only access to other data via properties.
+        self._all_attributes = attributes
+
+
+class AuthorityRecord(AlmaMARCRecord):
+    # These attributes are in addition to those defined in the base class.
+    __slots__ = [
+        "cataloging_level",
+        "record_format",
+        "vocabulary",
+    ]
+
+    def __init__(self, api_response: dict | None = None) -> None:
+        super().__init__(api_response)
+
+
+class BibRecord(AlmaMARCRecord):
+    # These attributes are in addition to those defined in the base class.
+    __slots__ = [
+        "brief_level",
+        "cataloging_level",
+        "record_format",
+        "suppress_from_publishing",
+    ]
+
+    def __init__(self, api_response: dict | None = None) -> None:
+        super().__init__(api_response)
+
+
+class HoldingsRecord(AlmaMARCRecord):
+    # These attributes are in addition to those defined in the base class.
+    __slots__ = [
+        "suppress_from_publishing",
+    ]
+
+    def __init__(self, api_response: dict | None = None) -> None:
+        super().__init__(api_response)
+
+    @property
+    def created_by(self) -> str:
+        return self._all_attributes.get("created_by", "")

--- a/src/alma_api_client/models/marc_records.py
+++ b/src/alma_api_client/models/marc_records.py
@@ -1,9 +1,7 @@
+import xmltodict
 import xml.etree.ElementTree as ET
 from io import BytesIO
 from pymarc import parse_xml_to_array, record_to_xml_node, Record
-
-import xmltodict
-from pprint import pprint
 
 
 class AlmaMARCRecord:
@@ -52,45 +50,72 @@ class AlmaMARCRecord:
         else:
             return None
 
-    def prepare_xml_for_update(self) -> bytes:
-        """Combines this object's pymarc record with the required Alma XML and returns
-        an updated bytes with MARCXML in the <record> element."""
-        # Convert data to ElementTree elements,
-        # using pymarc's record_to_xml_node to convert to MARCXML.
-        original_element = ET.fromstring(self.alma_xml)
-        new_record_element = record_to_xml_node(self.marc_record)
-
-        old_record_element = original_element.find("record")
-        if old_record_element is not None:
-            # Replace the old <record> element with the current MARCXML.
-            original_element.remove(old_record_element)
-            original_element.append(new_record_element)
-
-            # xml_declaration=False because the Alma API doesn't require it, and the API
-            # call fails if xml_declaration=True due to escape characters in ET's declaration
-            final_alma_xml = ET.tostring(
-                original_element, encoding="utf8", method="xml", xml_declaration=False
-            )
-            self.alma_xml = final_alma_xml
-            return final_alma_xml
-        else:
-            # TODO: Understand what errors can happen and handle them correctly
-            # For now, if XML not updated, return original XML?
-            return self.alma_xml
-
     def _set_attributes(self, alma_xml: bytes) -> None:
+        """Dynamically sets attributes from Alma data, which vary by subclass.
+        Attributes set are based on __slots__ for the current subclaass.
+        For the base class, no attributes are set as only subclass-specific data
+        can be retrieved from Alma.
+
+        :param alma_xml: XML data from an Alma MARC-specific API response.
+        :return: None
+        """
+        # Convert XML to dictionary, since we hate XML.
+        # TODO: Consider changing attr_prefix and cdata_key from xmltodict defaults.
         alma_data = xmltodict.parse(alma_xml)
-        pprint(alma_data, width=132)
+
         # Set specific attributes defined in __slots__ for read/write access.
         # There should be only one key in alma_data, indicating what type of record it is.
+        if len(alma_data) != 1:
+            raise ValueError("Unexpected data in {alma_data}")
+
+        # Only 1 key, representing record type (authority, bib, holding).
         self._record_type = next(iter(alma_data))
+        # All other attributes are the value of the record type key.
         attributes: dict = alma_data.get(self._record_type, {})
+        # For each attribute, if it matches something in __slots__, set it on this object.
+        # These attributes will be read/write for users of the object.
         for key, value in attributes.items():
             if key in self.__slots__:
                 setattr(self, key, value)
 
-        # Store as-is for read-only access to other data via properties.
+        # Store the whole collection of attributes for read-only access to other data
+        # via properties defined on subclasses.
         self._all_attributes = attributes
+
+    @property
+    def alma_xml(self) -> bytes:
+        """Build the XML required for Alma, combined with this object's pymarc record.
+        The pymarc record in self.marc_record is converted to MARCXML in the
+        <record> element.
+
+        :param: None
+        :return alma_xml: XML (as bytes) to be sent to the Alma API.
+        """
+        # Create a dict from the attributes represented by this object's __slots__,
+        # which are the only ones relevant for creating or updating Alma records.
+        attributes = {key: getattr(self, key, "") for key in self.__slots__}
+
+        # Convert this to XML, with record type as the root element.
+        alma_data = {self._record_type: attributes}
+        xml_data = xmltodict.unparse(alma_data)
+
+        # Convert the pymarc record to MARCXML.
+        marcxml = record_to_xml_node(self.marc_record)
+
+        # Treat this as real XML now, for node manipulation.
+        xml_element = ET.fromstring(xml_data)
+
+        # Add the MARCXML.
+        xml_element.append(marcxml)
+
+        # Convert it all to a (bytes) string for use by Alma API.
+        # xml_declaration=False because the Alma API doesn't require it, and the API
+        # call fails if xml_declaration=True due to escape characters in ET's declaration.
+        alma_xml = ET.tostring(
+            xml_element, encoding="utf8", method="xml", xml_declaration=False
+        )
+
+        return alma_xml
 
 
 class AuthorityRecord(AlmaMARCRecord):
@@ -103,6 +128,7 @@ class AuthorityRecord(AlmaMARCRecord):
 
     def __init__(self, api_response: dict | None = None) -> None:
         super().__init__(api_response)
+        self._record_type = "authority"
 
 
 class BibRecord(AlmaMARCRecord):
@@ -116,6 +142,11 @@ class BibRecord(AlmaMARCRecord):
 
     def __init__(self, api_response: dict | None = None) -> None:
         super().__init__(api_response)
+        self._record_type = "bib"
+
+    @property
+    def mms_id(self) -> str:
+        return self._all_attributes.get("mms_id", "")
 
 
 class HoldingsRecord(AlmaMARCRecord):
@@ -126,6 +157,7 @@ class HoldingsRecord(AlmaMARCRecord):
 
     def __init__(self, api_response: dict | None = None) -> None:
         super().__init__(api_response)
+        self._record_type = "holding"
 
     @property
     def created_by(self) -> str:


### PR DESCRIPTION
Implements [SYS-1971](https://uclalibrary.atlassian.net/browse/SYS-1971).

Goals:
* Hide the complexities.  Users should just be able to get the record they need, work with it via pymarc, and put it back.
* Fix legacy code, The API client was OK (though clumsy), but the `alma_marc` routines were named / focused on bib records, though they work with holdings too (and authority records, a later addition).
* Support record creation and deletion.  Currently we can only get and update existing records.  Record creation and deletion will be needed sometimes.

This PR reworks MARC support to achieve (I hope) all of those goals:
* New base class `AlmaMARCRecord`, which implements all of the code to convert Alma API XML responses to Python objects and back again.
  * This has no public methods, other than the constructor, which takes an optional `api_response` and parses data out of that.
  * Attributes which are allowed to be updated are exposed via `__slots__`, which (as implemented) prevents users of the objects from setting attributes which aren't allowed by the Alma API.
  * Attributes which aren't relevant for sending to Alma are not exposed via `__slots__`, so can't be set on these objects.  As desired, we can expose them via read-only `@property` decorators (on subclasses).
  * The base class has two public properties:
    *  `alma_xml`, which wraps the code to build the XML needed by the Alma APIs.  This is built on request, and expected to be requested only by the `AlmaAPIClient` methods when they send it to the APIs.  It's a property, so should be read-only.
    * `marc_record`, which exposes the pymarc record, either retrieved from Alma or provided by external programs.  This is read/write.
* New subclasses `AuthorityRecord`, `BibRecord` and `HoldingRecord`.  These extend the base class by defining new read/write attributes in their own `__slots__` (which add to the base class's values).  I've exposed a few read-only properties as well, and we can add more as needed.

Record retrieval and updating was shown in my draft PR last month.  That hasn't changed, other than code cleanup.  I've added `get_authority_record()` to the client, mainly to confirm my general approach works on those in addition to bibs and holdings.  I haven't added support for updating authority records, I'll do that in future work.

Testing: Edit and experiment with a variation on this, which create a bib record, adds a holdings record to it, then deletes both (in reverse order, due to dependencies).

There currently are no automated tests.  I intend to add some in future work.
```
import argparse
from alma_api_client import AlmaAPIClient
from pymarc import Field, Indicators, Record, Subfield
from alma_api_client.models.marc_records import BibRecord, HoldingRecord


def _get_arguments() -> argparse.Namespace:
    parser = argparse.ArgumentParser(description="Process metadata for MAMS ingestion.")
    parser.add_argument(
        "--api_key",
        help="SANDBOX API KEY",
        required=True,
    )
    return parser.parse_args()


def main() -> None:
    args = _get_arguments()
    client = AlmaAPIClient(args.api_key)

    # Create a very simple bib record.
    marc_bib = Record()
    title = Field(
        tag="245",
        indicators=Indicators("0", "0"),
        subfields=[Subfield(code="a", value="alma_api_demo test 245")],
    )
    marc_bib.add_field(title)

    print("---Creating bib record---")
    my_bib = BibRecord()
    my_bib.marc_record = marc_bib
    response = client.create_bib_record(my_bib)
    my_new_bib = BibRecord(response)

    print("---Showing new bib record---")
    print(my_new_bib.record_format)
    print(my_new_bib.suppress_from_publishing)
    print(my_new_bib.bib_id)
    print(my_new_bib.marc_record)

    # Create a very simple holding record.
    marc_hol = Record()
    f852 = Field(
        tag="852",
        indicators=Indicators("7", "_"),
        subfields=[
            Subfield(code="b", value="CLICC"),
            Subfield(code="c", value="cccollege"),
        ],
    )
    marc_hol.add_field(f852)

    print("---Creating holding record---")
    my_hol = HoldingRecord()
    my_hol.marc_record = marc_hol
    response = client.create_holding_record(my_new_bib.bib_id, my_hol)
    my_new_hol = HoldingRecord(response)

    print("---Showing new holding record---")
    print(my_new_hol.suppress_from_publishing)
    print(my_new_hol.holding_id)
    print(my_new_hol.marc_record)

    print("---Deleting new holding record---")
    client.delete_holding_record(my_new_bib.bib_id, my_new_hol.holding_id)
    # Still clumsy, for now
    print(response["api_response"]["status_code"])

    print("---Deleting new bib record---")
    client.delete_bib_record(my_new_bib.bib_id)
    # Still clumsy, for now
    print(response["api_response"]["status_code"])


if __name__ == "__main__":
    main()
```


[SYS-1971]: https://uclalibrary.atlassian.net/browse/SYS-1971?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ